### PR TITLE
🤖 issue-15: created_at, updated_atを日本時間に変更

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@prisma/client": "^6.14.0",
+        "dayjs": "^1.11.13",
         "dotenv": "^17.2.1",
         "express": "^5.1.0",
         "mysql2": "^3.14.3",
@@ -2433,6 +2434,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.13",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.13.tgz",
+      "integrity": "sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==",
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.1",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "description": "",
   "dependencies": {
     "@prisma/client": "^6.14.0",
+    "dayjs": "^1.11.13",
     "dotenv": "^17.2.1",
     "express": "^5.1.0",
     "mysql2": "^3.14.3",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -18,8 +18,8 @@ model Stock {
   name       String   @db.VarChar(255)
   count      Int      @default(0)
   url        String   @db.VarChar(500)
-  created_at DateTime @default(now())
-  updated_at DateTime @updatedAt
+  created_at DateTime
+  updated_at DateTime
 
   @@map("stock")
 }

--- a/src/__tests__/__mocks__/stock.ts
+++ b/src/__tests__/__mocks__/stock.ts
@@ -5,16 +5,16 @@ export const mockDbArray = [
     name: 'テスト商品1',
     count: 5,
     url: 'https://example.com/1',
-    created_at: new Date('2023-01-01'),
-    updated_at: new Date('2023-01-01'),
+    created_at: new Date('2023-01-01T00:00:00+09:00'),
+    updated_at: new Date('2023-01-01T00:00:00+09:00'),
   },
   {
     id: 2,
     name: 'テスト商品2',
     count: 10,
     url: 'https://example.com/2',
-    created_at: new Date('2023-01-02'),
-    updated_at: new Date('2023-01-02'),
+    created_at: new Date('2023-01-02T00:00:00+09:00'),
+    updated_at: new Date('2023-01-02T00:00:00+09:00'),
   },
 ];
 
@@ -26,18 +26,16 @@ export const mockUpdatedDbData = {
 };
 
 // APIデータ
-export const mockApiData = [
-  {
-    id: 1,
-    name: 'テスト商品',
-    count: 5,
-    url: 'https://example.com',
-    createdAt: new Date('2023-01-01T00:00:00Z'),
-    updatedAt: new Date('2023-01-01T00:00:00Z'),
-  },
-];
+export const mockApiData = {
+  id: 1,
+  name: 'テスト商品1',
+  count: 5,
+  url: 'https://example.com/1',
+  createdAt: new Date('2023-01-01T00:00:00+09:00'),
+  updatedAt: new Date('2023-01-01T00:00:00+09:00'),
+};
 
 export const mockUpdatedApiData = {
-  ...mockApiData[0],
+  ...mockApiData,
   count: 6,
 };

--- a/src/__tests__/controllers/stockController.test.ts
+++ b/src/__tests__/controllers/stockController.test.ts
@@ -7,7 +7,7 @@ import {
   postSubStockCountController,
 } from '../../controllers/stockController.js';
 import * as stockService from '../../services/stockService.js';
-import { mockApiData, mockDbArray } from '../__mocks__/stock.js';
+import { mockApiData } from '../__mocks__/stock.js';
 
 vi.mock('../../services/stockService.js');
 
@@ -43,12 +43,12 @@ describe('stockController', () => {
       const req = mockRequest();
       const res = mockResponse();
 
-      mockStockService.getAllStockService.mockResolvedValue(mockApiData);
+      mockStockService.getAllStockService.mockResolvedValue([mockApiData]);
 
       await getAllStockController(req as Request, res as Response, mockNext);
 
       expect(mockStockService.getAllStockService).toHaveBeenCalledTimes(1);
-      expect(res.json).toHaveBeenCalledWith(mockDbArray);
+      expect(res.json).toHaveBeenCalledWith([mockApiData]);
       expect(mockNext).not.toHaveBeenCalled();
     });
 
@@ -71,14 +71,14 @@ describe('stockController', () => {
       const req = mockRequest({ id: '1' });
       const res = mockResponse();
 
-      mockStockService.getStockService.mockResolvedValue(mockApiData);
+      mockStockService.getStockService.mockResolvedValue([mockApiData]);
 
       await getIdStockController(req as Request, res as Response, mockNext);
 
       expect(mockStockService.getStockService).toHaveBeenCalledWith({
         id: '1',
       });
-      expect(res.json).toHaveBeenCalledWith(mockApiData);
+      expect(res.json).toHaveBeenCalledWith([mockApiData]);
       expect(mockNext).not.toHaveBeenCalled();
     });
 
@@ -100,7 +100,7 @@ describe('stockController', () => {
     it('在庫個数を正常に追加できること', async () => {
       const req = mockRequest(undefined, { id: 1 });
       const res = mockResponse();
-      const updatedData = { ...mockApiData[0], count: 6 };
+      const updatedData = { ...mockApiData, count: 6 };
 
       mockStockService.postAddCountService.mockResolvedValue(updatedData);
 
@@ -139,7 +139,7 @@ describe('stockController', () => {
     it('在庫個数を正常に削除できること', async () => {
       const req = mockRequest(undefined, { id: 1 });
       const res = mockResponse();
-      const updatedData = { ...mockApiData[0], count: 4 };
+      const updatedData = { ...mockApiData, count: 4 };
 
       mockStockService.postSubCountService.mockResolvedValue(updatedData);
 

--- a/src/__tests__/services/stockService.test.ts
+++ b/src/__tests__/services/stockService.test.ts
@@ -151,7 +151,14 @@ describe('stockService', () => {
     it('在庫個数を正常に削除できること', async () => {
       const mockBody = { id: 1 };
       const updatedMockDbData = { ...mockDbData, count: 4 };
-      const updatedMockApiData = { ...mockApiData, count: 4 };
+      const expectedResult = {
+        id: 1,
+        name: 'テスト商品1',
+        count: 4,
+        url: 'https://example.com/1',
+        createdAt: new Date('2023-01-01T00:00:00+09:00'),
+        updatedAt: new Date('2023-01-01T00:00:00+09:00'),
+      };
 
       mockValidation.mockReturnValue({ id: 1 });
       mockStockModel.getById.mockResolvedValue(mockDbData);
@@ -165,7 +172,7 @@ describe('stockService', () => {
       );
       expect(mockStockModel.getById).toHaveBeenCalledWith(1);
       expect(mockStockModel.updateCount).toHaveBeenCalledWith(1, 4);
-      expect(result).toEqual(updatedMockApiData);
+      expect(result).toEqual(expectedResult);
     });
 
     it('存在しないIDの場合はエラーをスローすること', async () => {

--- a/src/__tests__/utils/timezone.test.ts
+++ b/src/__tests__/utils/timezone.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import {
+  getNowInJapan,
+  convertToJapanTime,
+  convertToUTC,
+  formatJapanTime,
+} from '../../utils/timezone.js';
+
+describe('timezone', () => {
+  describe('getNowInJapan', () => {
+    it('現在の日本時間を取得できること', () => {
+      const now = getNowInJapan();
+      expect(now).toBeInstanceOf(Date);
+    });
+  });
+
+  describe('convertToJapanTime', () => {
+    it('UTCの日時を日本時間に変換できること', () => {
+      const utcDate = new Date('2023-01-01T00:00:00.000Z');
+      const japanTime = convertToJapanTime(utcDate);
+
+      expect(japanTime).toBeInstanceOf(Date);
+      // 同じ時刻を表すDateオブジェクトとして返される
+      expect(japanTime.getTime()).toBe(utcDate.getTime());
+    });
+  });
+
+  describe('convertToUTC', () => {
+    it('日本時間の日時をUTCに変換できること', () => {
+      const japanDate = new Date('2023-01-01T09:00:00+09:00');
+      const utcTime = convertToUTC(japanDate);
+
+      expect(utcTime).toBeInstanceOf(Date);
+      // UTCの午前0時になることを確認
+      expect(utcTime.getUTCHours()).toBe(0);
+    });
+  });
+
+  describe('formatJapanTime', () => {
+    it('日付を日本時間の文字列表現で取得できること', () => {
+      const date = new Date('2023-01-01T00:00:00.000Z');
+      const formatted = formatJapanTime(date);
+
+      expect(formatted).toBe('2023-01-01 09:00:00');
+    });
+  });
+});

--- a/src/config/prisma.ts
+++ b/src/config/prisma.ts
@@ -1,11 +1,35 @@
 /* eslint-disable no-console */
 import { PrismaClient } from '@prisma/client';
+import { getNowInJapan } from '../utils/timezone.js';
 
 const globalForPrisma = globalThis as unknown as {
-  prisma: PrismaClient | undefined;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  prisma: any;
 };
 
-export const prisma = globalForPrisma.prisma ?? new PrismaClient();
+// 日本時間対応のクエリエクステンションを作成
+const basePrisma = new PrismaClient();
+export const prisma = basePrisma.$extends({
+  query: {
+    $allOperations({ args, query, operation }) {
+      // 作成・更新処理の場合、日本時間を設定
+      if ((operation === 'create' || operation === 'update') && args.data) {
+        const now = getNowInJapan();
+
+        if (operation === 'create') {
+          args.data.created_at = now;
+          args.data.updated_at = now;
+        } else if (operation === 'update') {
+          args.data.updated_at = now;
+        }
+      }
+
+      return query(args);
+    },
+  },
+});
+
+globalForPrisma.prisma = prisma;
 
 if (process.env.NODE_ENV !== 'production') globalForPrisma.prisma = prisma;
 

--- a/src/config/prisma.ts
+++ b/src/config/prisma.ts
@@ -3,13 +3,13 @@ import { PrismaClient } from '@prisma/client';
 import { getNowInJapan } from '../utils/timezone.js';
 
 const globalForPrisma = globalThis as unknown as {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  prisma: any;
+  prisma?: PrismaClient;
 };
 
 // 日本時間対応のクエリエクステンションを作成
-const basePrisma = new PrismaClient();
-export const prisma = basePrisma.$extends({
+const prismaBase = globalForPrisma.prisma ?? new PrismaClient();
+
+export const prisma = prismaBase.$extends({
   query: {
     $allOperations({ args, query, operation }) {
       // 作成・更新処理の場合、日本時間を設定
@@ -29,9 +29,9 @@ export const prisma = basePrisma.$extends({
   },
 });
 
-globalForPrisma.prisma = prisma;
-
-if (process.env.NODE_ENV !== 'production') globalForPrisma.prisma = prisma;
+if (process.env.NODE_ENV !== 'production') {
+  globalForPrisma.prisma = prismaBase;
+}
 
 export async function testPrismaConnection(): Promise<void> {
   try {

--- a/src/models/stock.ts
+++ b/src/models/stock.ts
@@ -1,5 +1,6 @@
 import { prisma } from '../config/prisma.js';
 import { StockDbData } from '../types/stockType.js';
+import { getNowInJapan } from '../utils/timezone.js';
 
 export class StockModel {
   static async getAll(): Promise<StockDbData[]> {
@@ -23,7 +24,10 @@ export class StockModel {
     try {
       const result = await prisma.stock.update({
         where: { id },
-        data: { count: newCount },
+        data: {
+          count: newCount,
+          updated_at: getNowInJapan(),
+        },
       });
       return result;
     } catch {

--- a/src/utils/timezone.ts
+++ b/src/utils/timezone.ts
@@ -1,0 +1,38 @@
+import dayjs from 'dayjs';
+import utc from 'dayjs/plugin/utc.js';
+import timezone from 'dayjs/plugin/timezone.js';
+
+// Day.jsプラグインを設定
+dayjs.extend(utc);
+dayjs.extend(timezone);
+
+// 日本時間のタイムゾーン
+const JAPAN_TIMEZONE = 'Asia/Tokyo';
+
+/**
+ * 現在の日本時間を取得
+ */
+export const getNowInJapan = (): Date => {
+  return dayjs().tz(JAPAN_TIMEZONE).toDate();
+};
+
+/**
+ * UTCのDateオブジェクトを日本時間に変換
+ */
+export const convertToJapanTime = (utcDate: Date): Date => {
+  return dayjs(utcDate).tz(JAPAN_TIMEZONE).toDate();
+};
+
+/**
+ * 日本時間のDateオブジェクトをUTCに変換
+ */
+export const convertToUTC = (japanDate: Date): Date => {
+  return dayjs.tz(japanDate, JAPAN_TIMEZONE).utc().toDate();
+};
+
+/**
+ * 日本時間の文字列表現を取得
+ */
+export const formatJapanTime = (date: Date): string => {
+  return dayjs(date).tz(JAPAN_TIMEZONE).format('YYYY-MM-DD HH:mm:ss');
+};


### PR DESCRIPTION
## 概要

- created_at, updated_atがUTCで保存されている問題を修正し、日本時間（JST）での処理に対応

## 関連 Issue

Closes #15

## 対応詳細

- Day.jsライブラリを導入してタイムゾーン機能を追加
- Prismaクエリエクステンションで日本時間の自動設定を実装
- タイムゾーン変換ユーティリティ関数を作成
- Prismaスキーマから自動タイムスタンプ設定を削除し手動制御に変更
- テストデータとテストケースを日本時間に対応するよう修正

🤖 Generated with [Claude Code](https://claude.ai/code)