### PR TITLE
🤖 issue-55: カートに挿入APIの作成

### DIFF
--- a/src/controllers/cartController.ts
+++ b/src/controllers/cartController.ts
@@ -1,0 +1,18 @@
+import { NextFunction, Request, Response } from 'express';
+import { insertToCart } from '../services/cartService';
+
+/**
+ * カート挿入API.
+ */
+export const postCartInsert = async (
+  _req: Request,
+  res: Response,
+  next: NextFunction
+) => {
+  try {
+    const response = await insertToCart();
+    res.json(response);
+  } catch (error) {
+    next(error);
+  }
+};

--- a/src/controllers/cartController.ts
+++ b/src/controllers/cartController.ts
@@ -1,16 +1,23 @@
 import { NextFunction, Request, Response } from 'express';
 import { insertToCart } from '../services/cartService';
+import { postCartInsertSchema } from '../schemas/cartSchema';
+import { CartInsertRequest } from '../types/cartType';
 
 /**
  * カート挿入API.
  */
 export const postCartInsert = async (
-  _req: Request,
+  req: Request,
   res: Response,
   next: NextFunction
 ) => {
   try {
-    const response = await insertToCart();
+    // リクエストボディのバリデーション
+    const validatedData: CartInsertRequest = postCartInsertSchema.parse(
+      req.body
+    );
+
+    const response = await insertToCart(validatedData.id);
     res.json(response);
   } catch (error) {
     next(error);

--- a/src/routes/cart.ts
+++ b/src/routes/cart.ts
@@ -1,0 +1,8 @@
+import { Router } from 'express';
+import { postCartInsert } from '../controllers/cartController';
+
+const router = Router();
+
+router.post('/insert', postCartInsert);
+
+export { router as cartRouter };

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -5,6 +5,7 @@ import { API_URL } from '../utils/const';
 import { getWeather } from '../controllers/weatherController';
 import { spentRouter } from './spent';
 import { lineRouter } from './line';
+import { cartRouter } from './cart';
 
 const router = Router();
 
@@ -13,6 +14,7 @@ router.use(API_URL.stock, stockRouter);
 router.use(API_URL.spent, spentRouter);
 router.use(API_URL.auth, authRouter);
 router.use(API_URL.line, lineRouter);
+router.use(API_URL.cart, cartRouter);
 
 // TODO:テスト後削除
 router.use('/weather', getWeather);

--- a/src/schemas/cartSchema.ts
+++ b/src/schemas/cartSchema.ts
@@ -1,0 +1,9 @@
+import z from 'zod';
+import { errorResponse } from '../utils/const';
+
+/**
+ * カート挿入API バリデーション.
+ */
+export const postCartInsertSchema = z.object({
+  id: z.coerce.number(errorResponse.idMustBeNumber),
+});

--- a/src/services/cartService.ts
+++ b/src/services/cartService.ts
@@ -1,13 +1,28 @@
+import { StockModel } from '../models/stock';
 import { errorResponse } from '../utils/const';
+import { CartInsertResponse } from '../types/cartType';
 
-export const insertToCart = async (): Promise<{ data: string }> => {
+export const insertToCart = async (id: number): Promise<CartInsertResponse> => {
   try {
-    // TODO: 今後スクレイピング機能を実装予定
-    // 現在は土台として基本的なレスポンスのみ返す
-    const data = 'カートに挿入しました（スクレイピング機能は未実装）';
+    // idに紐づく商品情報をStockテーブルから取得
+    const stock = await StockModel.getById(id);
 
-    return { data };
+    if (!stock) {
+      throw {
+        ...errorResponse.stockNotFound,
+        message: `ID: ${id}の商品が見つかりません`,
+      };
+    }
+
+    // TODO: 今後、取得したURLを使ってスクレイピング機能を実装予定
+    // 現在は商品URLを返すのみ
+    return { url: stock.url };
   } catch (error) {
+    // すでにエラーオブジェクトの場合はそのまま再throw
+    if (error && typeof error === 'object' && 'statusCode' in error) {
+      throw error;
+    }
+
     throw {
       ...errorResponse.cartInsertFailed,
       message: `カート挿入に失敗しました:${error}`,

--- a/src/services/cartService.ts
+++ b/src/services/cartService.ts
@@ -1,0 +1,16 @@
+import { errorResponse } from '../utils/const';
+
+export const insertToCart = async (): Promise<{ data: string }> => {
+  try {
+    // TODO: 今後スクレイピング機能を実装予定
+    // 現在は土台として基本的なレスポンスのみ返す
+    const data = 'カートに挿入しました（スクレイピング機能は未実装）';
+
+    return { data };
+  } catch (error) {
+    throw {
+      ...errorResponse.cartInsertFailed,
+      message: `カート挿入に失敗しました:${error}`,
+    };
+  }
+};

--- a/src/types/cartType.ts
+++ b/src/types/cartType.ts
@@ -1,0 +1,7 @@
+export interface CartInsertRequest {
+  id: number;
+}
+
+export interface CartInsertResponse {
+  url: string;
+}

--- a/src/utils/const.ts
+++ b/src/utils/const.ts
@@ -4,6 +4,7 @@ export const API_URL = {
   spent: '/spent',
   line: '/line',
   auth: '/auth',
+  cart: '/cart',
 };
 
 // stock
@@ -54,5 +55,16 @@ export const errorResponse = {
     name: 'Error',
     message: '金額は数字で入力してください',
     statusCode: 400,
+  },
+  // cart
+  cartNotFound: {
+    name: 'Error',
+    message: 'カート情報が見つかりません',
+    statusCode: 404,
+  },
+  cartInsertFailed: {
+    name: 'Error',
+    message: 'カートへの挿入に失敗しました',
+    statusCode: 500,
   },
 } as const;


### PR DESCRIPTION
## 概要

カート挿入API（POST /api/v1/cart/insert）の土台を作成

## 関連 Issue

Closes #55

## 対応詳細

- カート挿入用のルート（/api/v1/cart/insert）を追加
- weatherAPIと同様の構成でコントローラー・サービスを実装
- Prismaは使用せず、シンプルなレスポンス返却形式で実装
- スクレイピング機能は未実装（将来的に実装予定）
- エラーハンドリングを既存パターンに合わせて統一
- コードフォーマット・lint・型チェック完了

🤖 Generated with [Claude Code](https://claude.ai/code)