### PR TITLE
🤖 issue-44: APIアクセス時にheaderのkeyを確認するようにする

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,3 +35,6 @@ FIREBASE_MEASUREMENT_ID=""
 # Line
 LINE_CHANNEL_ACCESS_TOKEN=""
 LINE_USER_ID=""
+
+# API Access Key
+API_ACCESS_KEY="your_secret_api_key_here"

--- a/src/app.ts
+++ b/src/app.ts
@@ -4,6 +4,7 @@ import cors from 'cors';
 import { apiRouter } from './routes/index';
 import { BASE_URL } from './utils/const';
 import { errorHandler, notFoundHandler } from './middlewares/errorMiddleware';
+import { apiKeyAuth } from './middlewares/authMiddleware';
 import { FRONTEND_BASE_URL } from './config/common';
 
 const app = express();
@@ -17,7 +18,7 @@ app.use(
 );
 app.use(express.json());
 app.use(cookieParser());
-app.use(BASE_URL, apiRouter);
+app.use(BASE_URL, apiKeyAuth, apiRouter);
 app.use(notFoundHandler);
 app.use(errorHandler);
 

--- a/src/config/common.ts
+++ b/src/config/common.ts
@@ -13,3 +13,5 @@ export const SCRAPING_USER_AGENT = process.env.SCRAPING_USER_AGENT || '';
 export const LINE_CHANNEL_ACCESS_TOKEN =
   process.env.LINE_CHANNEL_ACCESS_TOKEN || '';
 export const LINE_USER_ID = process.env.LINE_USER_ID || '';
+
+export const API_ACCESS_KEY = process.env.API_ACCESS_KEY || '';

--- a/src/middlewares/authMiddleware.ts
+++ b/src/middlewares/authMiddleware.ts
@@ -1,0 +1,30 @@
+import { NextFunction, Request, Response } from 'express';
+import { API_ACCESS_KEY } from '../config/common';
+import { errorResponse } from '../utils/const';
+
+/**
+ * APIキー認証ミドルウェア
+ * リクエストヘッダーの'x-api-key'をチェックし、環境変数API_ACCESS_KEYと照合する
+ */
+export const apiKeyAuth = (req: Request, res: Response, next: NextFunction) => {
+  const apiKey = req.headers['x-api-key'];
+
+  // APIキーが存在しない場合
+  if (!apiKey) {
+    return res.status(401).json({
+      message: errorResponse.missingApiKey.message,
+      status: errorResponse.missingApiKey.statusCode,
+    });
+  }
+
+  // APIキーが一致しない場合
+  if (apiKey !== API_ACCESS_KEY) {
+    return res.status(401).json({
+      message: errorResponse.unauthorizedAccess.message,
+      status: errorResponse.unauthorizedAccess.statusCode,
+    });
+  }
+
+  // 認証成功時は次のミドルウェア/ルートに進む
+  next();
+};

--- a/src/utils/const.ts
+++ b/src/utils/const.ts
@@ -67,4 +67,15 @@ export const errorResponse = {
     message: 'カートへの挿入に失敗しました',
     statusCode: 500,
   },
+  // auth
+  unauthorizedAccess: {
+    name: 'Error',
+    message: 'APIキーが無効です',
+    statusCode: 401,
+  },
+  missingApiKey: {
+    name: 'Error',
+    message: 'APIキーが必要です',
+    statusCode: 401,
+  },
 } as const;


### PR DESCRIPTION
## 概要

全APIでheaderキー認証による不正アクセス防止を実装

## 関連 Issue

Closes #44

## 対応詳細

- 環境変数API_ACCESS_KEYによる認証キー管理を追加
- authMiddlewareを作成し、全API（/api/v1/*）に適用
- x-api-keyヘッダーの存在と値を検証
- 認証失敗時は401エラーを返却（キー不足・不正）
- 既存のerrorResponseに認証関連エラーを追加
- セキュリティ強化により不正利用を防止

🤖 Generated with [Claude Code](https://claude.ai/code)